### PR TITLE
Fix Auth Header bug, write tests and fix a few other bugs found

### DIFF
--- a/StickersTemplate.Tests/MessagesHttpFunctionTests.cs
+++ b/StickersTemplate.Tests/MessagesHttpFunctionTests.cs
@@ -1,0 +1,404 @@
+﻿//----------------------------------------------------------------------------------------------
+// <copyright file="MessagesHttpFunctionTests.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+//----------------------------------------------------------------------------------------------
+
+namespace StickersTemplate.Tests
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Bot.Connector.Authentication;
+    using Microsoft.Bot.Schema;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Primitives;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using Newtonsoft.Json;
+    using StickersTemplate.Interfaces;
+    using StickersTemplate.Models;
+    using StickersTemplate.WebModels;
+
+    using Mutex = System.Threading.Mutex;
+    using Task = System.Threading.Tasks.Task;
+    using CancellationToken = System.Threading.CancellationToken;
+
+    [ExcludeFromCodeCoverage]
+    [TestClass]
+    public class MessagesHttpFunctionTests
+    {
+        private readonly Mutex sequentialMutex = new Mutex(true, "ForceSequentialTests");
+
+        private readonly StickerSet stickerSet = new StickerSet("stickers", new Sticker[] {
+            new Sticker("sticker1", new Uri("http://localhost"), new string[] { "sticker1" } ),
+            new Sticker("sticker2", new Uri("http://localhost"), new string[] { "sticker2" } ),
+            new Sticker("sticker3", new Uri("http://localhost"), new string[] { "sticker3" } ),
+        });
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public async Task Run_NullRequest()
+        {
+            // Setup
+            var logger = new Mock<ILogger>();
+            var context = new ExecutionContext();
+
+            // Action
+            var result = await MessagesHttpFunction.Run(null, logger.Object, context);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public async Task Run_NullLogger()
+        {
+            // Setup
+            var request = new Mock<HttpRequest>();
+            var context = new ExecutionContext();
+
+            // Action
+            var result = await MessagesHttpFunction.Run(request.Object, null, context);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public async Task Run_NullExecutionContext()
+        {
+            // Setup
+            var request = new Mock<HttpRequest>();
+            var logger = new Mock<ILogger>();
+
+            // Action
+            var result = await MessagesHttpFunction.Run(request.Object, logger.Object, null);
+        }
+
+        [TestMethod]
+        public async Task Run_Request_MissingAllHeaders()
+        {
+            // Setup
+            var request = new Mock<HttpRequest>();
+            request.Setup((r) => r.Headers).Returns<IHeaderDictionary>(null);
+            var logger = new Mock<ILogger>();
+            var context = new ExecutionContext
+            {
+                FunctionAppDirectory = "localhost"
+            };
+
+            // Action
+            var result = await MessagesHttpFunction.Run(request.Object, logger.Object, context);
+
+            // Validation
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(UnauthorizedResult));
+        }
+
+        [TestMethod]
+        public async Task Run_Request_MissingAuthHeader1()
+        {
+            // Setup
+            var request = new Mock<HttpRequest>();
+            var headers = new Mock<IHeaderDictionary>();
+            request.Setup((r) => r.Headers).Returns(headers.Object);
+            var logger = new Mock<ILogger>();
+            var context = new ExecutionContext
+            {
+                FunctionAppDirectory = "localhost"
+            };
+
+            // Action
+            var result = await MessagesHttpFunction.Run(request.Object, logger.Object, context);
+
+            // Validation
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(UnauthorizedResult));
+        }
+
+        [TestMethod]
+        public async Task Run_Request_MissingAuthHeader2()
+        {
+            // Setup
+            var request = new Mock<HttpRequest>();
+            var headers = new Mock<IHeaderDictionary>();
+            StringValues authHeaders = new StringValues();
+            headers.Setup((h) => h.TryGetValue(It.Is<string>((s) => "Authorization".Equals(s)), out authHeaders)).Returns(true);
+            request.Setup((r) => r.Headers).Returns(headers.Object);
+            var logger = new Mock<ILogger>();
+            var context = new ExecutionContext
+            {
+                FunctionAppDirectory = "localhost"
+            };
+
+            // Action
+            var result = await MessagesHttpFunction.Run(request.Object, logger.Object, context);
+
+            // Validation
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(UnauthorizedResult));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public async Task Run_Request_MissingBody()
+        {
+            // Setup
+            var request = new Mock<HttpRequest>();
+            var headers = new Mock<IHeaderDictionary>();
+            StringValues authHeaders = new StringValues("Bearer adsf");
+            headers.Setup((h) => h.TryGetValue(It.Is<string>((s) => "Authorization".Equals(s)), out authHeaders)).Returns(true);
+            request.Setup((r) => r.Headers).Returns(headers.Object);
+            var logger = new Mock<ILogger>();
+            var context = new ExecutionContext
+            {
+                FunctionAppDirectory = "localhost"
+            };
+
+            // Action
+            var result = await MessagesHttpFunction.Run(request.Object, logger.Object, context);
+
+            // Validation
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(UnauthorizedResult));
+        }
+
+        [TestMethod]
+        public async Task Run_Request_Body_NotJSON()
+        {
+            // Setup
+            var request = new Mock<HttpRequest>();
+            var headers = new Mock<IHeaderDictionary>();
+            StringValues authHeaders = new StringValues("");
+            headers.Setup((h) => h.TryGetValue(It.Is<string>((s) => "Authorization".Equals(s)), out authHeaders)).Returns(true);
+            request.Setup((r) => r.Headers).Returns(headers.Object);
+            var body = new MemoryStream();
+            request.Setup((r) => r.Body).Returns(body);
+
+            var logger = new Mock<ILogger>();
+            var context = new ExecutionContext
+            {
+                FunctionAppDirectory = "localhost"
+            };
+
+            // Action
+            var result = await MessagesHttpFunction.Run(request.Object, logger.Object, context);
+
+            // Validation
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(BadRequestResult));
+        }
+
+        [TestMethod]
+        public async Task Run_Request_Body_NotComposeExtensionQuery1()
+        {
+            // Setup
+            var request = new Mock<HttpRequest>();
+            var headers = new Mock<IHeaderDictionary>();
+            StringValues authHeaders = new StringValues("");
+            headers.Setup((h) => h.TryGetValue(It.Is<string>((s) => "Authorization".Equals(s)), out authHeaders)).Returns(true);
+            request.Setup((r) => r.Headers).Returns(headers.Object);
+
+            var activity = new Activity()
+            {
+                Type = ActivityTypes.Message
+            };
+            var body = new MemoryStream(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(activity)));
+            request.Setup((r) => r.Body).Returns(body);
+
+            var logger = new Mock<ILogger>();
+            var context = new ExecutionContext
+            {
+                FunctionAppDirectory = "localhost"
+            };
+
+            // Action
+            var result = await MessagesHttpFunction.Run(request.Object, logger.Object, context);
+
+            // Validation
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(BadRequestObjectResult));
+        }
+
+        [TestMethod]
+        public async Task Run_Request_Body_NoValue()
+        {
+            // Setup
+            var request = new Mock<HttpRequest>();
+            var headers = new Mock<IHeaderDictionary>();
+            StringValues authHeaders = new StringValues("");
+            headers.Setup((h) => h.TryGetValue(It.Is<string>((s) => "Authorization".Equals(s)), out authHeaders)).Returns(true);
+            request.Setup((r) => r.Headers).Returns(headers.Object);
+
+            var activity = new Activity()
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "composeExtension/query"
+            };
+            var body = new MemoryStream(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(activity)));
+            request.Setup((r) => r.Body).Returns(body);
+
+            var logger = new Mock<ILogger>();
+            var context = new ExecutionContext
+            {
+                FunctionAppDirectory = "localhost"
+            };
+
+            // Action
+            var result = await MessagesHttpFunction.Run(request.Object, logger.Object, context);
+
+            // Validation
+            Assert.IsNotNull(result);
+            ValidateResponse(result, stickerSet.Count());
+        }
+
+        [TestMethod]
+        public async Task Run_Request_Body_QueryValue_NoResults()
+        {
+            // Setup
+            var request = new Mock<HttpRequest>();
+            var headers = new Mock<IHeaderDictionary>();
+            StringValues authHeaders = new StringValues("");
+            headers.Setup((h) => h.TryGetValue(It.Is<string>((s) => "Authorization".Equals(s)), out authHeaders)).Returns(true);
+            request.Setup((r) => r.Headers).Returns(headers.Object);
+
+            var activity = new Activity()
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "composeExtension/query",
+                Value = new ComposeExtensionValue
+                {
+                    CommandId = "commandId",
+                    Parameters = new ComposeExtensionParameter[]
+                    {
+                        new ComposeExtensionParameter
+                        {
+                            Name = "search",
+                            Value = "search"
+                        }
+                    },
+                    QueryOptions = new ComposeExtensionQueryOptions
+                    {
+                        Count = 10,
+                        Skip = 0
+                    }
+                }
+            };
+            var body = new MemoryStream(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(activity)));
+            request.Setup((r) => r.Body).Returns(body);
+
+            var logger = new Mock<ILogger>();
+            var context = new ExecutionContext
+            {
+                FunctionAppDirectory = "localhost"
+            };
+
+            // Action
+            var result = await MessagesHttpFunction.Run(request.Object, logger.Object, context);
+
+            // Validation
+            Assert.IsNotNull(result);
+            ValidateResponse(result, 0);
+        }
+
+        [TestMethod]
+        public async Task Run_Request_Body_QueryValue_WithResults()
+        {
+            // Setup
+            var request = new Mock<HttpRequest>();
+            var headers = new Mock<IHeaderDictionary>();
+            StringValues authHeaders = new StringValues("");
+            headers.Setup((h) => h.TryGetValue(It.Is<string>((s) => "Authorization".Equals(s)), out authHeaders)).Returns(true);
+            request.Setup((r) => r.Headers).Returns(headers.Object);
+
+            var activity = new Activity()
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "composeExtension/query",
+                Value = new ComposeExtensionValue
+                {
+                    CommandId = "commandId",
+                    Parameters = new ComposeExtensionParameter[]
+                    {
+                        new ComposeExtensionParameter
+                        {
+                            Name = "search",
+                            Value = stickerSet.First().Name
+                        }
+                    },
+                    QueryOptions = new ComposeExtensionQueryOptions
+                    {
+                        Count = 10,
+                        Skip = 0
+                    }
+                }
+            };
+            var body = new MemoryStream(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(activity)));
+            request.Setup((r) => r.Body).Returns(body);
+
+            var logger = new Mock<ILogger>();
+            var context = new ExecutionContext
+            {
+                FunctionAppDirectory = "localhost"
+            };
+
+            // Action
+            var result = await MessagesHttpFunction.Run(request.Object, logger.Object, context);
+
+            // Validation
+            Assert.IsNotNull(result);
+            ValidateResponse(result, 1);
+        }
+
+        private void ValidateResponse(IActionResult result, int numExpectedAttachments)
+        {
+            Assert.IsInstanceOfType(result, typeof(OkObjectResult));
+            var okResult = result as OkObjectResult;
+            var response = okResult.Value;
+
+            Assert.IsNotNull(response);
+            Assert.IsInstanceOfType(response, typeof(ComposeExtensionResponse));
+            var composeExtensionResponse = response as ComposeExtensionResponse;
+            var composeExtensionResult = composeExtensionResponse.ComposeExtensionResult;
+
+            Assert.IsNotNull(composeExtensionResult);
+            Assert.AreEqual(composeExtensionResult.Type, "result");
+            Assert.AreEqual(composeExtensionResult.AttachmentLayout, "grid");
+            Assert.IsNotNull(composeExtensionResult.Attachments);
+            Assert.AreEqual(numExpectedAttachments, composeExtensionResult.Attachments.Length);
+        }
+
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            sequentialMutex.WaitOne(TimeSpan.FromSeconds(1));
+
+            var settings = new Mock<ISettings>();
+            settings.Setup((s) => s.ConfigUri).Returns(new Uri("http://localhost"));
+            settings.Setup((s) => s.MicrosoftAppId).Returns(Guid.NewGuid().ToString());
+
+            var stickerSetRepository = new Mock<IStickerSetRepository>();
+            stickerSetRepository.Setup((s) => s.FetchStickerSetAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(stickerSet);
+
+            var stickerSetIndexer = new Mock<IStickerSetIndexer>();
+            stickerSetIndexer.Setup((s) => s.IndexStickerSetAsync(It.IsAny<StickerSet>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            stickerSetIndexer.Setup((s) => s.FindStickersByQuery(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string query, CancellationToken token) => stickerSet.Where(s => string.IsNullOrWhiteSpace(query) || s.Name.Equals(query)));
+
+            var credentialProvider = new Mock<ICredentialProvider>();
+            credentialProvider.Setup((c) => c.IsAuthenticationDisabledAsync()).ReturnsAsync(true);
+            var channelProvider = new Mock<IChannelProvider>();
+            MessagesHttpFunction.ConfigureForTests(settings.Object, stickerSetRepository.Object, stickerSetIndexer.Object, credentialProvider.Object, channelProvider.Object);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            sequentialMutex.ReleaseMutex();
+        }
+    }
+}

--- a/StickersTemplate.Tests/StickersTemplate.Tests.csproj
+++ b/StickersTemplate.Tests/StickersTemplate.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\StickersTemplate\StickersTemplate.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/StickersTemplate.sln
+++ b/StickersTemplate.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.28307.168
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StickersTemplate", "StickersTemplate\StickersTemplate.csproj", "{DE0FAB3D-7C99-401F-8151-6677B01AEE0B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StickersTemplate", "StickersTemplate\StickersTemplate.csproj", "{DE0FAB3D-7C99-401F-8151-6677B01AEE0B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StickersTemplate.Tests", "StickersTemplate.Tests\StickersTemplate.Tests.csproj", "{E31D696B-F67C-4C9E-9328-98B0ABEE0B03}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{DE0FAB3D-7C99-401F-8151-6677B01AEE0B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DE0FAB3D-7C99-401F-8151-6677B01AEE0B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DE0FAB3D-7C99-401F-8151-6677B01AEE0B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E31D696B-F67C-4C9E-9328-98B0ABEE0B03}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E31D696B-F67C-4C9E-9328-98B0ABEE0B03}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E31D696B-F67C-4C9E-9328-98B0ABEE0B03}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E31D696B-F67C-4C9E-9328-98B0ABEE0B03}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/StickersTemplate/MessagesHttpFunction.cs
+++ b/StickersTemplate/MessagesHttpFunction.cs
@@ -7,6 +7,7 @@
 namespace StickersTemplate
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
@@ -31,6 +32,36 @@ namespace StickersTemplate
     /// </summary>
     public static class MessagesHttpFunction
     {
+        private static ISettings settings;
+        private static IStickerSetRepository stickerSetRepository;
+        private static IStickerSetIndexer stickerSetIndexer;
+        private static ICredentialProvider credentialProvider;
+        private static IChannelProvider channelProvider;
+
+        /// <summary>
+        /// Configures the services used by this Azure function for a test run.
+        /// This is necessary because of the static nature of Azure functions (and lack of DI).
+        /// </summary>
+        /// <param name="settings">The <see cref="ISettings"/>.</param>
+        /// <param name="stickerSetRepository">The <see cref="IStickerSetRepository"/>.</param>
+        /// <param name="stickerSetIndexer">The <see cref="IStickerSetIndexer"/>.</param>
+        /// <param name="credentialProvider">The <see cref="ICredentialProvider"/>.</param>
+        /// <param name="channelProvider">The <see cref="IChannelProvider"/>.</param>
+        [ExcludeFromCodeCoverage]
+        public static void ConfigureForTests(
+            ISettings settings,
+            IStickerSetRepository stickerSetRepository,
+            IStickerSetIndexer stickerSetIndexer,
+            ICredentialProvider credentialProvider,
+            IChannelProvider channelProvider)
+        {
+            MessagesHttpFunction.settings = settings ?? throw new ArgumentNullException(nameof(settings));
+            MessagesHttpFunction.stickerSetRepository = stickerSetRepository ?? throw new ArgumentNullException(nameof(stickerSetRepository));
+            MessagesHttpFunction.stickerSetIndexer = stickerSetIndexer ?? throw new ArgumentNullException(nameof(stickerSetIndexer));
+            MessagesHttpFunction.credentialProvider = credentialProvider ?? throw new ArgumentNullException(nameof(credentialProvider));
+            MessagesHttpFunction.channelProvider = channelProvider ?? throw new ArgumentNullException(nameof(channelProvider));
+        }
+
         /// <summary>
         /// Method that is called by the Azure Function framework when this Azure Function is invoked.
         /// </summary>
@@ -44,15 +75,31 @@ namespace StickersTemplate
             ILogger logger,
             ExecutionContext context)
         {
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
             using (var scope = logger.BeginScope($"{nameof(MessagesHttpFunction.Run)}"))
             {
+                if (req == null)
+                {
+                    throw new ArgumentNullException(nameof(req));
+                }
+
+                if (context == null)
+                {
+                    throw new ArgumentNullException(nameof(context));
+                }
+
                 logger.LogInformation("Messages function received a request.");
 
-                ISettings settings = new Settings(logger, context);
-                IStickerSetRepository stickerSetRepository = new StickerSetRepository(logger, settings);
-                IStickerSetIndexer stickerSetIndexer = new StickerSetIndexer(logger);
-                ICredentialProvider credentialProvider = new SimpleCredentialProvider(settings.MicrosoftAppId, null);
-                IChannelProvider channelProvider = new SimpleChannelProvider();
+                // Use the configured service for tests or create the real one to use.
+                ISettings settings = MessagesHttpFunction.settings ?? new Settings(logger, context);
+                IStickerSetRepository stickerSetRepository = MessagesHttpFunction.stickerSetRepository ?? new StickerSetRepository(logger, settings);
+                IStickerSetIndexer stickerSetIndexer = MessagesHttpFunction.stickerSetIndexer ?? new StickerSetIndexer(logger);
+                ICredentialProvider credentialProvider = MessagesHttpFunction.credentialProvider ?? new SimpleCredentialProvider(settings.MicrosoftAppId, null);
+                IChannelProvider channelProvider = MessagesHttpFunction.channelProvider ?? new SimpleChannelProvider();
 
                 Activity activity;
                 try
@@ -78,8 +125,12 @@ namespace StickersTemplate
                     return new BadRequestObjectResult($"App only supports compose extension query activity types.");
                 }
 
-                var queryValue = JObject.FromObject(activity.Value).ToObject<ComposeExtensionValue>();
-                var query = queryValue.GetParameterValue();
+                var query = string.Empty;
+                if (activity.Value != null)
+                {
+                    var queryValue = JObject.FromObject(activity.Value).ToObject<ComposeExtensionValue>();
+                    query = queryValue.GetParameterValue();
+                }
 
                 var stickerSet = await stickerSetRepository.FetchStickerSetAsync();
                 await stickerSetIndexer.IndexStickerSetAsync(stickerSet);
@@ -107,7 +158,7 @@ namespace StickersTemplate
         /// <returns>The authorization header.</returns>
         private static string GetAuthorizationHeader(HttpRequest req)
         {
-            if (!req.Headers.TryGetValue("Authorization", out var authHeaders) && authHeaders.Count < 1)
+            if (req.Headers == null || !req.Headers.TryGetValue("Authorization", out var authHeaders) || authHeaders.Count < 1)
             {
                 throw new UnauthorizedAccessException();
             }
@@ -123,6 +174,11 @@ namespace StickersTemplate
         /// <returns>The <see cref="Activity"/> object.</returns>
         private static async Task<Activity> ParseRequestBody(HttpRequest req)
         {
+            if (req.Body == null)
+            {
+                throw new InvalidOperationException($"{nameof(req)}.{nameof(req.Body)} cannot be null");
+            }
+
             using (var streamReader = new StreamReader(req.Body))
             using (var jsonReader = new JsonTextReader(streamReader))
             {


### PR DESCRIPTION
Fix bug with Auth header crashing app if not provided.
Add tests to the Azure function.
Fix additional crashes that occur when an invalid activity is sent.