### PR TITLE
Resize the uploaded images to a maximum size (default 640 px)

### DIFF
--- a/StickersTemplate.Configuration/Models/Sticker.cs
+++ b/StickersTemplate.Configuration/Models/Sticker.cs
@@ -15,6 +15,11 @@ namespace StickersTemplate.Configuration.Models
     public class Sticker
     {
         /// <summary>
+        /// Maximum dimension of a sticker in pixels
+        /// </summary>
+        public const int MaximumDimensionInPixels = 640;
+
+        /// <summary>
         /// Gets or sets Id
         /// </summary>
         public string Id { get; set; }

--- a/StickersTemplate.Configuration/StickersTemplate.Configuration.csproj
+++ b/StickersTemplate.Configuration/StickersTemplate.Configuration.csproj
@@ -49,6 +49,9 @@
     <DocumentationFile>bin\Release\StickersTemplate.Configuration.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ImageResizer, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ImageResizer.4.2.5\lib\net45\ImageResizer.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.ApplicationInsights.Agent.Intercept.2.4.0\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>
     </Reference>
@@ -281,6 +284,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="Properties\PublishProfiles\stickersdeploytest1-config - Web Deploy.pubxml" />
   </ItemGroup>
   <ItemGroup>
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />

--- a/StickersTemplate.Configuration/Views/Stickers/Create.cshtml
+++ b/StickersTemplate.Configuration/Views/Stickers/Create.cshtml
@@ -17,7 +17,7 @@
         <div class="form-group">
             @Html.LabelFor(model => model.ImageUri, htmlAttributes: new { @class = "control-label col-md-2" })
             <div class="col-md-10">
-                <img id="imgFile" src="#" alt="Selected image" class="hidden" width="250"/>
+                <img id="imgFile" src="#" alt="Selected image" class="hidden" width="280"/>
                 <input class="form-control" type="file" name="File" accept="image/gif, image/jpeg, image/png" onchange="readURL(this);" />
                 @Html.ValidationMessageFor(model => model.File, "", new { @class = "text-danger" })
             </div>

--- a/StickersTemplate.Configuration/Views/Stickers/Delete.cshtml
+++ b/StickersTemplate.Configuration/Views/Stickers/Delete.cshtml
@@ -18,7 +18,7 @@
         </dt>
 
         <dd>
-            <img src="@Model.ImageUri" width="250" />
+            <img src="@Model.ImageUri" width="280" />
         </dd>
 
         <dt>

--- a/StickersTemplate.Configuration/Views/Stickers/Edit.cshtml
+++ b/StickersTemplate.Configuration/Views/Stickers/Edit.cshtml
@@ -19,7 +19,7 @@
         <div class="form-group">
             @Html.LabelFor(model => model.ImageUri, htmlAttributes: new { @class = "control-label col-md-2" })
             <div class="col-md-10">
-                <img src="@Model.ImageUri" width="250" />
+                <img src="@Model.ImageUri" width="280" />
             </div>
         </div>
 

--- a/StickersTemplate.Configuration/Views/Stickers/Index.cshtml
+++ b/StickersTemplate.Configuration/Views/Stickers/Index.cshtml
@@ -30,7 +30,7 @@
     {
         <tr>
             <td>
-                <img src="@item.ImageUri" width="250" />
+                <img src="@item.ImageUri" width="280" />
             </td>
             <td>
                 @item.Name

--- a/StickersTemplate.Configuration/packages.config
+++ b/StickersTemplate.Configuration/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net462" />
+  <package id="ImageResizer" version="4.2.5" targetFramework="net462" />
   <package id="Microsoft.ApplicationInsights" version="2.9.1" targetFramework="net462" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net462" />
   <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.9.0" targetFramework="net462" />


### PR DESCRIPTION
If the uploaded image is too large, the teams URL Previewer rejects the image, which results in an error.
To prevent this, resize the image to a maximum dimension of 640px before saving it to the blob store.